### PR TITLE
Fix: gtk_widget_unparent usage

### DIFF
--- a/src/polyhymnia-albums-page.c
+++ b/src/polyhymnia-albums-page.c
@@ -154,9 +154,6 @@ static void
 polyhymnia_albums_page_mpd_database_updated (PolyhymniaAlbumsPage *self,
                                              PolyhymniaMpdClient  *user_data)
 {
-  GtkWidget *new_child;
-  GtkWidget *previous_child;
-
   g_assert (POLYHYMNIA_IS_ALBUMS_PAGE (self));
 
   if (self->albums_cancellable != NULL)
@@ -170,17 +167,11 @@ polyhymnia_albums_page_mpd_database_updated (PolyhymniaAlbumsPage *self,
                                              polyhymnia_albums_page_search_albums_callback,
                                              self);
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  new_child = GTK_WIDGET (self->albums_spinner);
   gtk_spinner_start (self->albums_spinner);
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != GTK_WIDGET (self->albums_spinner))
   {
-    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
+    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), GTK_WIDGET (self->albums_spinner));
   }
 }
 
@@ -193,10 +184,7 @@ polyhymnia_albums_page_search_albums_callback (GObject      *source_object,
   GError               *error = NULL;
   PolyhymniaMpdClient  *mpd_client = POLYHYMNIA_MPD_CLIENT (source_object);
   GtkWidget            *new_child;
-  GtkWidget            *previous_child;
   PolyhymniaAlbumsPage *self = user_data;
-
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
 
   albums = polyhymnia_mpd_client_search_albums_finish (mpd_client, result,
                                                        &error);
@@ -238,13 +226,9 @@ polyhymnia_albums_page_search_albums_callback (GObject      *source_object,
     return;
   }
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 
   gtk_spinner_stop (self->albums_spinner);

--- a/src/polyhymnia-artists-page.c
+++ b/src/polyhymnia-artists-page.c
@@ -612,9 +612,6 @@ static void
 polyhymnia_artists_page_mpd_database_updated (PolyhymniaArtistsPage *self,
                                               PolyhymniaMpdClient   *user_data)
 {
-  GtkWidget *previous_child;
-  GtkWidget *new_child;
-
   g_assert (POLYHYMNIA_IS_ARTISTS_PAGE (self));
 
   if (self->artists_cancellable != NULL)
@@ -631,17 +628,11 @@ polyhymnia_artists_page_mpd_database_updated (PolyhymniaArtistsPage *self,
 
   gtk_selection_model_unselect_all (GTK_SELECTION_MODEL (self->artist_tracks_selection_model));
   gtk_selection_model_unselect_all (GTK_SELECTION_MODEL (self->artists_selection_model));
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  new_child = GTK_WIDGET (self->artists_spinner);
   gtk_spinner_start (self->artists_spinner);
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != GTK_WIDGET (self->artists_spinner))
   {
-    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
+    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), GTK_WIDGET (self->artists_spinner));
   }
 }
 
@@ -654,7 +645,6 @@ polyhymnia_artists_page_search_artists_callback (GObject      *source_object,
   GError                *error = NULL;
   PolyhymniaMpdClient   *mpd_client = POLYHYMNIA_MPD_CLIENT (source_object);
   GtkWidget             *new_child;
-  GtkWidget             *previous_child;
   PolyhymniaArtistsPage *self = user_data;
 
   artists = polyhymnia_mpd_client_search_artists_finish (mpd_client, result, &error);
@@ -697,14 +687,9 @@ polyhymnia_artists_page_search_artists_callback (GObject      *source_object,
     return;
   }
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 
   gtk_spinner_stop (self->artists_spinner);

--- a/src/polyhymnia-current-lyrics-pane.c
+++ b/src/polyhymnia-current-lyrics-pane.c
@@ -147,18 +147,16 @@ polyhymnia_current_lyrics_pane_current_track_changed (PolyhymniaCurrentLyricsPan
   webkit_web_view_stop_loading (self->lyrics_web_view);
 
   current_track = polyhymnia_player_get_current_track (user_data);
-  if (adw_toolbar_view_get_content (self->root_toolbar_view) != NULL)
-  {
-    gtk_widget_unparent (adw_toolbar_view_get_content (self->root_toolbar_view));
-  }
-
   if (current_track == NULL)
   {
     g_object_set (G_OBJECT (self->lyrics_status_page),
                   "description", _("No current song"),
                   NULL);
-    adw_toolbar_view_set_content (self->root_toolbar_view,
-                                  GTK_WIDGET (self->lyrics_status_page));
+    if (adw_toolbar_view_get_content (self->root_toolbar_view) != GTK_WIDGET (self->lyrics_status_page))
+    {
+      adw_toolbar_view_set_content (self->root_toolbar_view,
+                                    GTK_WIDGET (self->lyrics_status_page));
+    }
   }
   else
   {
@@ -168,8 +166,11 @@ polyhymnia_current_lyrics_pane_current_track_changed (PolyhymniaCurrentLyricsPan
     search_lyrics_request->artist = g_strdup (polyhymnia_track_get_artist (current_track));
     search_lyrics_request->title = g_strdup (polyhymnia_track_get_title (current_track));
 
-    adw_toolbar_view_set_content (self->root_toolbar_view,
-                                  GTK_WIDGET (self->spinner));
+    if (adw_toolbar_view_get_content (self->root_toolbar_view) != GTK_WIDGET (self->spinner))
+    {
+      adw_toolbar_view_set_content (self->root_toolbar_view,
+                                    GTK_WIDGET (self->spinner));
+    }
     gtk_spinner_start (self->spinner);
     self->lyrics_cancellable = g_cancellable_new ();
     polyhymnia_lyrics_provider_search_lyrics_async (self->lyrics_provider,
@@ -239,12 +240,11 @@ polyhymnia_current_lyrics_pane_lyrics_web_view_load_changed (PolyhymniaCurrentLy
 
   if (load_event == WEBKIT_LOAD_FINISHED)
   {
-    if (adw_toolbar_view_get_content (self->root_toolbar_view) != NULL)
+    if (adw_toolbar_view_get_content (self->root_toolbar_view) != GTK_WIDGET (self->lyrics_web_view))
     {
-      gtk_widget_unparent (adw_toolbar_view_get_content (self->root_toolbar_view));
+      adw_toolbar_view_set_content (self->root_toolbar_view,
+                                    GTK_WIDGET (self->lyrics_web_view));
     }
-    adw_toolbar_view_set_content (self->root_toolbar_view,
-                                  GTK_WIDGET (self->lyrics_web_view));
     adw_toolbar_view_set_reveal_top_bars (self->root_toolbar_view, TRUE);
   }
 }
@@ -272,12 +272,11 @@ polyhymnia_current_lyrics_pane_search_lyrics_callback (GObject      *source,
       g_object_set (G_OBJECT (self->lyrics_status_page),
                     "description", _("Failed to find song lyrics"),
                     NULL);
-      if (adw_toolbar_view_get_content (self->root_toolbar_view) != NULL)
+      if (adw_toolbar_view_get_content (self->root_toolbar_view) != GTK_WIDGET (self->lyrics_status_page))
       {
-        gtk_widget_unparent (adw_toolbar_view_get_content (self->root_toolbar_view));
+        adw_toolbar_view_set_content (self->root_toolbar_view,
+                                      GTK_WIDGET (self->lyrics_status_page));
       }
-      adw_toolbar_view_set_content (self->root_toolbar_view,
-                                    GTK_WIDGET (self->lyrics_status_page));
       gtk_spinner_stop (self->spinner);
     }
   }
@@ -286,12 +285,11 @@ polyhymnia_current_lyrics_pane_search_lyrics_callback (GObject      *source,
     g_object_set (G_OBJECT (self->lyrics_status_page),
                   "description", _("No song lyrics found"),
                   NULL);
-    if (adw_toolbar_view_get_content (self->root_toolbar_view) != NULL)
+    if (adw_toolbar_view_get_content (self->root_toolbar_view) != GTK_WIDGET (self->lyrics_status_page))
     {
-      gtk_widget_unparent (adw_toolbar_view_get_content (self->root_toolbar_view));
+      adw_toolbar_view_set_content (self->root_toolbar_view,
+                                    GTK_WIDGET (self->lyrics_status_page));
     }
-    adw_toolbar_view_set_content (self->root_toolbar_view,
-                                  GTK_WIDGET (self->lyrics_status_page));
     gtk_spinner_stop (self->spinner);
   }
   else
@@ -348,3 +346,4 @@ polyhymnia_current_lyrics_pane_show_uri_callback (GObject      *source_object,
     g_error_free (error);
   }
 }
+

--- a/src/polyhymnia-last-modified-page.c
+++ b/src/polyhymnia-last-modified-page.c
@@ -186,7 +186,6 @@ polyhymnia_last_modified_page_get_last_modified_tracks_callback (GObject      *s
   GError    *error = NULL;
   PolyhymniaMpdClient *mpd_client = POLYHYMNIA_MPD_CLIENT (source_object);
   GtkWidget *new_child;
-  GtkWidget *previous_child;
   PolyhymniaLastModifiedPage *self = user_data;
   GPtrArray *tracks;
 
@@ -235,14 +234,9 @@ polyhymnia_last_modified_page_get_last_modified_tracks_callback (GObject      *s
     return;
   }
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 
   gtk_spinner_stop (self->spinner);
@@ -271,9 +265,7 @@ polyhymnia_last_modified_page_mpd_database_updated (PolyhymniaLastModifiedPage *
                                                     PolyhymniaMpdClient  *user_data)
 {
   GDateTime *last_modified_since;
-  GtkWidget *new_child;
   GDateTime *now;
-  GtkWidget *previous_child;
 
   g_assert (POLYHYMNIA_IS_LAST_MODIFIED_PAGE (self));
 
@@ -292,17 +284,11 @@ polyhymnia_last_modified_page_mpd_database_updated (PolyhymniaLastModifiedPage *
   g_date_time_unref (last_modified_since);
   g_date_time_unref (now);
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  new_child = GTK_WIDGET (self->spinner);
   gtk_spinner_start (self->spinner);
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != GTK_WIDGET (self->spinner))
   {
-    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
+    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), GTK_WIDGET (self->spinner));
   }
 }
 

--- a/src/polyhymnia-playlists-page.c
+++ b/src/polyhymnia-playlists-page.c
@@ -122,7 +122,6 @@ polyhymnia_playlists_page_search_playlists_callback (GObject      *source_object
   PolyhymniaMpdClient *mpd_client = POLYHYMNIA_MPD_CLIENT (source_object);
   GtkWidget *new_child;
   GPtrArray *playlists;
-  GtkWidget *previous_child;
   PolyhymniaPlaylistsPage *self = user_data;
 
   playlists = polyhymnia_mpd_client_search_playlists_finish (mpd_client, result,
@@ -171,14 +170,9 @@ polyhymnia_playlists_page_search_playlists_callback (GObject      *source_object
     return;
   }
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 
   gtk_spinner_stop (self->spinner);
@@ -212,26 +206,17 @@ polyhymnia_playlists_page_mpd_playlists_changed (PolyhymniaPlaylistsPage *self,
 
   if (self->playlists_cancellable == NULL)
   {
-    GtkWidget *new_child;
-    GtkWidget *previous_child;
-
     self->playlists_cancellable = g_cancellable_new ();
     polyhymnia_mpd_client_search_playlists_async (mpd_client,
                                                   self->playlists_cancellable,
                                                   polyhymnia_playlists_page_search_playlists_callback,
                                                   self);
 
-    new_child = GTK_WIDGET (self->spinner);
-    previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
     gtk_spinner_start (self->spinner);
 
-    if (new_child != previous_child)
+    if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != GTK_WIDGET (self->spinner))
     {
-      adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-      if (previous_child != NULL)
-      {
-        gtk_widget_unparent (previous_child);
-      }
+      adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), GTK_WIDGET (self->spinner));
     }
   }
 }

--- a/src/polyhymnia-search-page.c
+++ b/src/polyhymnia-search-page.c
@@ -272,9 +272,6 @@ static void
 polyhymnia_search_page_fill (PolyhymniaSearchPage *self)
 {
   GtkWidget *new_child;
-  GtkWidget *previous_child;
-
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
 
   if (self->search_query == NULL
       // Simple trick to avoid O(N) string length measurement
@@ -330,13 +327,9 @@ polyhymnia_search_page_fill (PolyhymniaSearchPage *self)
     }
   }
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 }
 

--- a/src/polyhymnia-track-details-dialog.c
+++ b/src/polyhymnia-track-details-dialog.c
@@ -485,12 +485,11 @@ polyhymnia_track_details_dialog_get_song_details_callback (GObject      *source_
       search_lyrics_request->title = g_strdup (polyhymnia_track_full_info_get_title (details));
 
       self->song_lyrics_cancellable = g_cancellable_new ();
-      if (adw_toolbar_view_get_content (self->lyrics_page_content) != NULL)
+      if (adw_toolbar_view_get_content (self->lyrics_page_content) != GTK_WIDGET (self->lyrics_spinner))
       {
-        gtk_widget_unparent (adw_toolbar_view_get_content (self->lyrics_page_content));
+        adw_toolbar_view_set_content (self->lyrics_page_content,
+                                      GTK_WIDGET (g_object_ref (self->lyrics_spinner)));
       }
-      adw_toolbar_view_set_content (self->lyrics_page_content,
-                                    GTK_WIDGET (g_object_ref (self->lyrics_spinner)));
       gtk_spinner_start (self->lyrics_spinner);
       polyhymnia_lyrics_provider_search_lyrics_async (self->lyrics_provider,
                                                       search_lyrics_request,
@@ -705,12 +704,11 @@ polyhymnia_track_details_dialog_lyrics_web_view_load_changed (PolyhymniaTrackDet
 
   if (load_event == WEBKIT_LOAD_FINISHED)
   {
-    if (adw_toolbar_view_get_content (self->lyrics_page_content) != NULL)
+    if (adw_toolbar_view_get_content (self->lyrics_page_content) != GTK_WIDGET (self->lyrics_web_view))
     {
-      gtk_widget_unparent (adw_toolbar_view_get_content (self->lyrics_page_content));
+      adw_toolbar_view_set_content (self->lyrics_page_content,
+                                    GTK_WIDGET (g_object_ref (self->lyrics_web_view)));
     }
-    adw_toolbar_view_set_content (self->lyrics_page_content,
-                                  GTK_WIDGET (g_object_ref (self->lyrics_web_view)));
   }
 }
 
@@ -737,12 +735,11 @@ polyhymnia_track_details_dialog_search_song_lyrics_callback (GObject      *sourc
       g_object_set (G_OBJECT (self->lyrics_status_page),
                     "description", _("Failed to find song lyrics"),
                     NULL);
-      if (adw_toolbar_view_get_content (self->lyrics_page_content) != NULL)
+      if (adw_toolbar_view_get_content (self->lyrics_page_content) != GTK_WIDGET (self->lyrics_status_page))
       {
-        gtk_widget_unparent (adw_toolbar_view_get_content (self->lyrics_page_content));
+        adw_toolbar_view_set_content (self->lyrics_page_content,
+                                      GTK_WIDGET (g_object_ref (self->lyrics_status_page)));
       }
-      adw_toolbar_view_set_content (self->lyrics_page_content,
-                                    GTK_WIDGET (g_object_ref (self->lyrics_status_page)));
       gtk_spinner_stop (GTK_SPINNER (self->lyrics_spinner));
     }
   }
@@ -751,12 +748,11 @@ polyhymnia_track_details_dialog_search_song_lyrics_callback (GObject      *sourc
     g_object_set (G_OBJECT (self->lyrics_status_page),
                   "description", _("No song lyrics found"),
                   NULL);
-    if (adw_toolbar_view_get_content (self->lyrics_page_content) != NULL)
+    if (adw_toolbar_view_get_content (self->lyrics_page_content) != GTK_WIDGET (self->lyrics_status_page))
     {
-      gtk_widget_unparent (adw_toolbar_view_get_content (self->lyrics_page_content));
+      adw_toolbar_view_set_content (self->lyrics_page_content,
+                                    GTK_WIDGET (g_object_ref (self->lyrics_status_page)));
     }
-    adw_toolbar_view_set_content (self->lyrics_page_content,
-                                  GTK_WIDGET (g_object_ref (self->lyrics_status_page)));
     gtk_spinner_stop (GTK_SPINNER (self->lyrics_spinner));
   }
   else

--- a/src/polyhymnia-tracks-page.c
+++ b/src/polyhymnia-tracks-page.c
@@ -200,9 +200,6 @@ static void
 polyhymnia_tracks_page_mpd_database_updated (PolyhymniaTracksPage *self,
                                              PolyhymniaMpdClient  *user_data)
 {
-  GtkWidget *previous_child;
-  GtkWidget *new_child;
-
   g_assert (POLYHYMNIA_IS_TRACKS_PAGE (self));
 
   if (self->tracks_cancellable != NULL)
@@ -216,17 +213,11 @@ polyhymnia_tracks_page_mpd_database_updated (PolyhymniaTracksPage *self,
                                              polyhymnia_tracks_page_search_tracks_callback,
                                              self);
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  new_child = GTK_WIDGET (self->spinner);
   gtk_spinner_start (self->spinner);
 
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != GTK_WIDGET (self->spinner))
   {
-    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
+    adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), GTK_WIDGET (self->spinner));
   }
 }
 
@@ -261,7 +252,6 @@ polyhymnia_tracks_page_search_tracks_callback (GObject *source_object,
   GError    *error = NULL;
   PolyhymniaMpdClient *mpd_client = POLYHYMNIA_MPD_CLIENT (source_object);
   GtkWidget *new_child;
-  GtkWidget *previous_child;
   PolyhymniaTracksPage *self = user_data;
   GPtrArray *tracks;
   tracks = polyhymnia_mpd_client_search_tracks_finish (mpd_client, result, &error);
@@ -308,14 +298,9 @@ polyhymnia_tracks_page_search_tracks_callback (GObject *source_object,
     return;
   }
 
-  previous_child = adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self));
-  if (new_child != previous_child)
+  if (adw_navigation_page_get_child (ADW_NAVIGATION_PAGE (self)) != new_child)
   {
     adw_navigation_page_set_child (ADW_NAVIGATION_PAGE (self), new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 
   gtk_spinner_stop (self->spinner);

--- a/src/polyhymnia-window.c
+++ b/src/polyhymnia-window.c
@@ -323,10 +323,6 @@ polyhymnia_window_mpd_client_initialized (PolyhymniaWindow    *self,
   if (new_child != previous_child)
   {
     adw_toast_overlay_set_child (self->root_toast_overlay, new_child);
-    if (previous_child != NULL)
-    {
-      gtk_widget_unparent (previous_child);
-    }
   }
 }
 


### PR DESCRIPTION
- fixed crash caused by careless `gtk_widget_unparent` usage,
- got rid of unnecessary`gtk_widget_unparent` calls